### PR TITLE
Update mxGraph.java

### DIFF
--- a/src/com/mxgraph/view/mxGraph.java
+++ b/src/com/mxgraph/view/mxGraph.java
@@ -7838,7 +7838,17 @@ public class mxGraph extends mxEventSource
 			{
 				Graphics g = ((mxGraphics2DCanvas) clippedCanvas).getGraphics();
 				clip = g.getClip();
-				g.setClip(newClip);
+
+				// Ensure that our new clip resides within our old clip
+				if (clip instanceof Rectangle)
+				{
+					g.setClip(newClip.intersection((Rectangle) clip));
+				}
+				// Otherwise, default to original implementation
+				else
+				{
+					g.setClip(newClip);
+				}
 			}
 
 			if (drawLabel)


### PR DESCRIPTION
Fix to ensure clipped labels are constrained to the original clipping area they originated from.

Bug and fix are outlined here:
http://goo.gl/3s9PP2
