### PR TITLE
Image shape style that uses an image loaded in memory, instead of reading it from an image path.

### DIFF
--- a/src/com/mxgraph/canvas/mxBasicCanvas.java
+++ b/src/com/mxgraph/canvas/mxBasicCanvas.java
@@ -158,4 +158,13 @@ public abstract class mxBasicCanvas implements mxICanvas
 		return filename;
 	}
 
+    /**
+     * Gets image that is already loaded into memory, from the given style.
+     */
+    public java.awt.Image getLoadedImageForStyle(Map<String, Object> style)
+    {
+        java.awt.Image img = mxUtils.getImage(style, mxConstants.STYLE_IMAGE);
+        return img;
+    }
+
 }

--- a/src/com/mxgraph/canvas/mxGraphics2DCanvas.java
+++ b/src/com/mxgraph/canvas/mxGraphics2DCanvas.java
@@ -22,28 +22,7 @@ import java.util.Map;
 
 import javax.swing.CellRendererPane;
 
-import com.mxgraph.shape.mxActorShape;
-import com.mxgraph.shape.mxArrowShape;
-import com.mxgraph.shape.mxCloudShape;
-import com.mxgraph.shape.mxConnectorShape;
-import com.mxgraph.shape.mxCurveShape;
-import com.mxgraph.shape.mxCylinderShape;
-import com.mxgraph.shape.mxDefaultTextShape;
-import com.mxgraph.shape.mxDoubleEllipseShape;
-import com.mxgraph.shape.mxDoubleRectangleShape;
-import com.mxgraph.shape.mxEllipseShape;
-import com.mxgraph.shape.mxHexagonShape;
-import com.mxgraph.shape.mxHtmlTextShape;
-import com.mxgraph.shape.mxIShape;
-import com.mxgraph.shape.mxITextShape;
-import com.mxgraph.shape.mxImageShape;
-import com.mxgraph.shape.mxLabelShape;
-import com.mxgraph.shape.mxLineShape;
-import com.mxgraph.shape.mxRectangleShape;
-import com.mxgraph.shape.mxRhombusShape;
-import com.mxgraph.shape.mxStencilRegistry;
-import com.mxgraph.shape.mxSwimlaneShape;
-import com.mxgraph.shape.mxTriangleShape;
+import com.mxgraph.shape.*;
 import com.mxgraph.swing.util.mxSwingConstants;
 import com.mxgraph.util.mxConstants;
 import com.mxgraph.util.mxPoint;
@@ -98,6 +77,7 @@ public class mxGraphics2DCanvas extends mxBasicCanvas
 		putShape(mxConstants.SHAPE_ELLIPSE, new mxEllipseShape());
 		putShape(mxConstants.SHAPE_HEXAGON, new mxHexagonShape());
 		putShape(mxConstants.SHAPE_IMAGE, new mxImageShape());
+        putShape(mxConstants.SHAPE_LOADED_IMAGE, new mxLoadedImageShape());
 		putShape(mxConstants.SHAPE_LABEL, new mxLabelShape());
 		putShape(mxConstants.SHAPE_LINE, new mxLineShape());
 		putShape(mxConstants.SHAPE_RECTANGLE, new mxRectangleShape());
@@ -287,80 +267,89 @@ public class mxGraphics2DCanvas extends mxBasicCanvas
 		drawImage(bounds, imageUrl, PRESERVE_IMAGE_ASPECT, false, false);
 	}
 
+    public void drawImage(Rectangle bounds, java.awt.Image img)
+    {
+        drawImage( bounds, img, PRESERVE_IMAGE_ASPECT, false, false );
+    }
+
 	/**
 	 * 
 	 */
 	public void drawImage(Rectangle bounds, String imageUrl,
-			boolean preserveAspect, boolean flipH, boolean flipV)
+                          boolean preserveAspect, boolean flipH, boolean flipV)
 	{
 		if (imageUrl != null && bounds.getWidth() > 0 && bounds.getHeight() > 0)
 		{
-			Image img = loadImage(imageUrl);
-
-			if (img != null)
-			{
-				int w, h;
-				int x = bounds.x;
-				int y = bounds.y;
-				Dimension size = getImageSize(img);
-
-				if (preserveAspect)
-				{
-					double s = Math.min(bounds.width / (double) size.width,
-							bounds.height / (double) size.height);
-					w = (int) (size.width * s);
-					h = (int) (size.height * s);
-					x += (bounds.width - w) / 2;
-					y += (bounds.height - h) / 2;
-				}
-				else
-				{
-					w = bounds.width;
-					h = bounds.height;
-				}
-
-				Image scaledImage = (w == size.width && h == size.height) ? img
-						: img.getScaledInstance(w, h, IMAGE_SCALING);
-
-				if (scaledImage != null)
-				{
-					AffineTransform af = null;
-
-					if (flipH || flipV)
-					{
-						af = g.getTransform();
-						int sx = 1;
-						int sy = 1;
-						int dx = 0;
-						int dy = 0;
-
-						if (flipH)
-						{
-							sx = -1;
-							dx = -w - 2 * x;
-						}
-
-						if (flipV)
-						{
-							sy = -1;
-							dy = -h - 2 * y;
-						}
-
-						g.scale(sx, sy);
-						g.translate(dx, dy);
-					}
-
-					drawImageImpl(scaledImage, x, y);
-
-					// Restores the previous transform
-					if (af != null)
-					{
-						g.setTransform(af);
-					}
-				}
-			}
+            java.awt.Image img = loadImage(imageUrl);
+            drawImage(bounds, img, preserveAspect, flipH, flipV);
 		}
 	}
+
+    public void drawImage(Rectangle bounds, java.awt.Image img,
+                           boolean preserveAspect, boolean flipH, boolean flipV) {
+        if (img != null)
+        {
+            int w, h;
+            int x = bounds.x;
+            int y = bounds.y;
+            Dimension size = getImageSize(img);
+
+            if (preserveAspect)
+            {
+                double s = Math.min(bounds.width / (double) size.width,
+                        bounds.height / (double) size.height);
+                w = (int) (size.width * s);
+                h = (int) (size.height * s);
+                x += (bounds.width - w) / 2;
+                y += (bounds.height - h) / 2;
+            }
+            else
+            {
+                w = bounds.width;
+                h = bounds.height;
+            }
+
+            Image scaledImage = (w == size.width && h == size.height) ? img
+                    : img.getScaledInstance(w, h, IMAGE_SCALING);
+
+            if (scaledImage != null)
+            {
+                AffineTransform af = null;
+
+                if (flipH || flipV)
+                {
+                    af = g.getTransform();
+                    int sx = 1;
+                    int sy = 1;
+                    int dx = 0;
+                    int dy = 0;
+
+                    if (flipH)
+                    {
+                        sx = -1;
+                        dx = -w - 2 * x;
+                    }
+
+                    if (flipV)
+                    {
+                        sy = -1;
+                        dy = -h - 2 * y;
+                    }
+
+                    g.scale(sx, sy);
+                    g.translate(dx, dy);
+                }
+
+                drawImageImpl(scaledImage, x, y);
+
+                // Restores the previous transform
+                if (af != null)
+                {
+                    g.setTransform(af);
+                }
+            }
+        }
+    }
 
 	/**
 	 * Implements the actual graphics call.

--- a/src/com/mxgraph/shape/mxLoadedImageShape.java
+++ b/src/com/mxgraph/shape/mxLoadedImageShape.java
@@ -1,0 +1,76 @@
+package com.mxgraph.shape;
+
+import java.awt.Color;
+import java.awt.Rectangle;
+
+import com.mxgraph.canvas.mxGraphics2DCanvas;
+import com.mxgraph.util.mxConstants;
+import com.mxgraph.util.mxUtils;
+import com.mxgraph.view.mxCellState;
+
+/**
+ * A rectangular shape that contains a single image
+ */
+public class mxLoadedImageShape extends mxRectangleShape
+{
+
+    /**
+     *
+     */
+    public void paintShape(mxGraphics2DCanvas canvas, mxCellState state)
+    {
+        super.paintShape(canvas, state);
+
+        boolean flipH = mxUtils.isTrue( state.getStyle(),
+                mxConstants.STYLE_IMAGE_FLIPH, false );
+        boolean flipV = mxUtils.isTrue(state.getStyle(),
+                mxConstants.STYLE_IMAGE_FLIPV, false);
+
+        canvas.drawImage(getImageBounds(canvas, state),
+                getLoadedImageForStyle(canvas, state),
+                mxGraphics2DCanvas.PRESERVE_IMAGE_ASPECT, flipH, flipV);
+    }
+
+    /**
+     *
+     */
+    public Rectangle getImageBounds(mxGraphics2DCanvas canvas, mxCellState state)
+    {
+        return state.getRectangle();
+    }
+
+    /**
+     *
+     */
+    public boolean hasGradient(mxGraphics2DCanvas canvas, mxCellState state)
+    {
+        return false;
+    }
+
+    /**
+     *
+     */
+    public java.awt.Image getLoadedImageForStyle(mxGraphics2DCanvas canvas, mxCellState state)
+    {
+        return canvas.getLoadedImageForStyle(state.getStyle());
+    }
+
+    /**
+     *
+     */
+    public Color getFillColor(mxGraphics2DCanvas canvas, mxCellState state)
+    {
+        return mxUtils.getColor(state.getStyle(),
+                mxConstants.STYLE_IMAGE_BACKGROUND);
+    }
+
+    /**
+     *
+     */
+    public Color getStrokeColor(mxGraphics2DCanvas canvas, mxCellState state)
+    {
+        return mxUtils.getColor(state.getStyle(),
+                mxConstants.STYLE_IMAGE_BORDER);
+    }
+
+}

--- a/src/com/mxgraph/util/mxConstants.java
+++ b/src/com/mxgraph/util/mxConstants.java
@@ -990,7 +990,12 @@ public class mxConstants
 	 */
 	public static final String SHAPE_IMAGE = "image";
 
-	/**
+    /**
+     * SHAPE_IMAGE
+     */
+    public static final String SHAPE_LOADED_IMAGE = "image";
+
+    /**
 	 * SHAPE_ARROW
 	 */
 	public static final String SHAPE_ARROW = "arrow";

--- a/src/com/mxgraph/util/mxUtils.java
+++ b/src/com/mxgraph/util/mxUtils.java
@@ -1677,6 +1677,21 @@ public class mxUtils
 		return new Font(fontFamily, swingFontStyle, (int) (fontSize * scale));
 	}
 
+    /**
+     * Returns the value for key in dictionary as an Image.
+     *
+     * @param dict
+     *            Dictionary that contains the key, value pairs.
+     * @param key
+     *            Key whose value should be returned.
+     * @return Returns the integer value for key in dict.
+     */
+    public static java.awt.Image getImage(Map<String, Object> dict, String key)
+    {
+        Object value = dict.get(key);
+        return (java.awt.Image)value;
+    }
+
 	/**
 	 * 
 	 */


### PR DESCRIPTION
Added a shape style called mxLoadedImageShape, that allows the use of an image that is loaded into memory. Instead of mxImageShape, which requires the path to an image stored on file.
