### PR TITLE
#31 Removing remaining references to the commercial JGraph license.

### DIFF
--- a/examples/com/mxgraph/examples/swing/editor/ShadowBorder.java
+++ b/examples/com/mxgraph/examples/swing/editor/ShadowBorder.java
@@ -1,13 +1,6 @@
-/*
+/**
  * $Id: ShadowBorder.java,v 1.1 2012/11/15 13:26:46 gaudenz Exp $
  * Copyright (c) 2001-2005, Gaudenz Alder
- * 
- * All rights reserved. 
- * 
- * This file is licensed under the JGraph software license, a copy of which
- * will have been provided to you in the file LICENSE at the root of your
- * installation directory. If you are unable to locate this file please
- * contact JGraph sales for another copy.
  */
 package com.mxgraph.examples.swing.editor;
 

--- a/src/com/mxgraph/analysis/mxGraphAnalysis.java
+++ b/src/com/mxgraph/analysis/mxGraphAnalysis.java
@@ -1,13 +1,6 @@
-/*
+/**
  * $Id: mxGraphAnalysis.java,v 1.2 2012/11/21 14:16:01 mate Exp $
  * Copyright (c) 2001-2005, Gaudenz Alder
- * 
- * All rights reserved. 
- * 
- * This file is licensed under the JGraph software license, a copy of which
- * will have been provided to you in the file LICENSE at the root of your
- * installation directory. If you are unable to locate this file please
- * contact JGraph sales for another copy.
  */
 package com.mxgraph.analysis;
 

--- a/src/com/mxgraph/layout/hierarchical/model/mxGraphHierarchyEdge.java
+++ b/src/com/mxgraph/layout/hierarchical/model/mxGraphHierarchyEdge.java
@@ -1,12 +1,5 @@
-/*
+/**
  * Copyright (c) 2005, David Benson
- *
- * All rights reserved.
- *
- * This file is licensed under the JGraph software license, a copy of which
- * will have been provided to you in the file LICENSE at the root of your
- * installation directory. If you are unable to locate this file please
- * contact JGraph sales for another copy.
  */
 package com.mxgraph.layout.hierarchical.model;
 

--- a/src/com/mxgraph/layout/hierarchical/model/mxGraphHierarchyNode.java
+++ b/src/com/mxgraph/layout/hierarchical/model/mxGraphHierarchyNode.java
@@ -1,12 +1,5 @@
-/*
+/**
  * Copyright (c) 2005, David Benson
- *
- * All rights reserved.
- *
- * This file is licensed under the JGraph software license, a copy of which
- * will have been provided to you in the file LICENSE at the root of your
- * installation directory. If you are unable to locate this file please
- * contact JGraph sales for another copy.
  */
 package com.mxgraph.layout.hierarchical.model;
 

--- a/src/com/mxgraph/layout/hierarchical/model/mxGraphHierarchyRank.java
+++ b/src/com/mxgraph/layout/hierarchical/model/mxGraphHierarchyRank.java
@@ -1,12 +1,5 @@
-/*
+/**
  * Copyright (c) 2005, David Benson
- *
- * All rights reserved.
- *
- * This file is licensed under the JGraph software license, a copy of which
- * will have been provided to you in the file LICENSE at the root of your
- * installation directory. If you are unable to locate this file please
- * contact JGraph sales for another copy.
  */
 package com.mxgraph.layout.hierarchical.model;
 

--- a/src/com/mxgraph/layout/hierarchical/stage/mxHierarchicalLayoutStage.java
+++ b/src/com/mxgraph/layout/hierarchical/stage/mxHierarchicalLayoutStage.java
@@ -1,12 +1,5 @@
-/* 
+/**
  * Copyright (c) 2005, David Benson
- * 
- * All rights reserved. 
- * 
- * This file is licensed under the JGraph software license, a copy of which
- * will have been provided to you in the file LICENSE at the root of your
- * installation directory. If you are unable to locate this file please
- * contact JGraph sales for another copy.
  */
 package com.mxgraph.layout.hierarchical.stage;
 

--- a/src/com/mxgraph/layout/hierarchical/stage/mxMedianHybridCrossingReduction.java
+++ b/src/com/mxgraph/layout/hierarchical/stage/mxMedianHybridCrossingReduction.java
@@ -1,12 +1,5 @@
-/*
+/**
  * Copyright (c) 2005-2009, JGraph Ltd
- *
- * All rights reserved.
- *
- * This file is licensed under the JGraph software license, a copy of which
- * will have been provided to you in the file LICENSE at the root of your
- * installation directory. If you are unable to locate this file please
- * contact JGraph sales for another copy.
  */
 
 package com.mxgraph.layout.hierarchical.stage;

--- a/src/com/mxgraph/layout/hierarchical/stage/mxMinimumCycleRemover.java
+++ b/src/com/mxgraph/layout/hierarchical/stage/mxMinimumCycleRemover.java
@@ -1,12 +1,5 @@
-/*
+/**
  * Copyright (c) 2005, David Benson
- *
- * All rights reserved.
- *
- * This file is licensed under the JGraph software license, a copy of which
- * will have been provided to you in the file LICENSE at the root of your
- * installation directory. If you are unable to locate this file please
- * contact JGraph sales for another copy.
  */
 package com.mxgraph.layout.hierarchical.stage;
 


### PR DESCRIPTION
Solves issue #31

If modifying your file headers in this way is not acceptable please accept my apologies.  It was done purely for the sake of having consistent BSD licensing throughout the library and to make it easy for you to apply the necessary changes.