### PR TITLE
Parse Dash Pattern

### DIFF
--- a/src/com/mxgraph/canvas/mxGraphicsCanvas2D.java
+++ b/src/com/mxgraph/canvas/mxGraphicsCanvas2D.java
@@ -352,15 +352,7 @@ public class mxGraphicsCanvas2D implements mxICanvas2D
 	{
 		if (value != null && value.length() > 0)
 		{
-			String[] tokens = value.split(" ");
-			float[] dashpattern = new float[tokens.length];
-
-			for (int i = 0; i < tokens.length; i++)
-			{
-				dashpattern[i] = (float) (Float.parseFloat(tokens[i]));
-			}
-
-			state.dashPattern = dashpattern;
+			state.dashPattern = mxUtils.parseDashPattern(value);
 		}
 	}
 

--- a/src/com/mxgraph/util/mxUtils.java
+++ b/src/com/mxgraph/util/mxUtils.java
@@ -1715,6 +1715,36 @@ public class mxUtils
 	{
 		return mxHtmlColor.getHexColorString(color);
 	}
+	
+	/**
+	 * Convert a string representing a dash pattern into a float array.
+	 * A valid dash pattern is a string of dash widths (floating point values)
+	 * separated by space characters.
+	 * 
+	 * @param dashPatternString
+	 *            the string representing the dash pattern
+	 * @return float[]
+	 * @exception NumberFormatException
+	 *                if any of the dash widths cannot be interpreted as a
+	 *                floating point number
+	 */
+	public static float[] parseDashPattern(String dashPatternString)
+			throws NumberFormatException
+	{
+		if (value != null && value.length() > 0)
+		{
+			String[] tokens = dashPatternString.split(" ");
+			float[] dashpattern = new float[tokens.length];
+			
+			for (int i = 0; i < tokens.length; i++)
+			{
+				dashpattern[i] = (float) (Float.parseFloat(tokens[i]));
+			}
+			
+			return dashpattern;
+		}
+		return null;
+	}
 
 	/**
 	 * Reads the given filename into a string.

--- a/src/com/mxgraph/util/mxUtils.java
+++ b/src/com/mxgraph/util/mxUtils.java
@@ -1731,14 +1731,23 @@ public class mxUtils
 	public static float[] parseDashPattern(String dashPatternString)
 			throws NumberFormatException
 	{
-		if (value != null && value.length() > 0)
+		if (dashPatternString != null && dashPatternString.length() > 0)
 		{
 			String[] tokens = dashPatternString.split(" ");
 			float[] dashpattern = new float[tokens.length];
+			float dashWidth;
 			
 			for (int i = 0; i < tokens.length; i++)
 			{
-				dashpattern[i] = (float) (Float.parseFloat(tokens[i]));
+				dashWidth = (float) (Float.parseFloat(tokens[i]));
+				if (dashWidth > 0)
+				{
+					dashpattern[i] = dashWidth;
+				}
+				else
+				{
+					throw NumberFormatException("Dash width must be positive");
+				}
 			}
 			
 			return dashpattern;


### PR DESCRIPTION
I'd like to validate a dash pattern that I'm giving to JGraph, and it makes most sense for this validation to be done inside JGraph in case the number separator (currently space) or number type (currently float) changes in the future (the former is not available as a style constant).

It looks like com.mxgraph.canvas.mxGraphics2DCanvas could also be refactored to use this mxUtils.parseDashPattern
https://github.com/jgraph/jgraphx/blob/774aa8d63b178ea7995875902ac018600f4e554f/src/com/mxgraph/canvas/mxGraphics2DCanvas.java#L518
https://github.com/jgraph/jgraphx/blob/774aa8d63b178ea7995875902ac018600f4e554f/src/com/mxgraph/canvas/mxGraphicsCanvas2D.java#L355

I was not sure what behavior mxUtils.parseDashPattern should take on when the dash pattern string is null or empty string, whether it return the JGraph default dash pattern (https://github.com/jgraph/jgraphx/blob/1c4000edd211923136ea4f11e8554ed1696cc030/src/com/mxgraph/canvas/mxGraphicsCanvas2D.java#L1650), an empty float array, null, or throw an exception.