### PR TITLE
Osgify the JGraphX Java lib using the maven-bundle-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,34 @@
 			</resource>
 		</resources>
   	<plugins>
-  	
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-jar-plugin</artifactId>
+			<version>2.6</version>
+			<configuration>
+				<archive>
+					<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+				</archive>
+			</configuration>
+		</plugin>
+		<plugin>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>maven-bundle-plugin</artifactId>
+			<version>3.0.1</version>
+			<executions>
+				<execution>
+					<phase>process-classes</phase>
+					<goals>
+						<goal>manifest</goal>
+					</goals>
+				</execution>
+			</executions>
+			<configuration>
+				<instructions>
+					<Bundle-Vendor>see https://github.com/jgraph/jgraphx)</Bundle-Vendor>
+				</instructions>
+			</configuration>
+		</plugin>
   	</plugins>
   </build>
 </project>


### PR DESCRIPTION
- The JGraphX Java library can now be used in OSGi environments
  (e.g. Eclipse RCP applications) in a proper way.