### PR TITLE
Maven POM improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# maven
+/target/
+# eclipse
+/bin/
+/classes/
+/.settings/
+/.classpath
+/.project
+# it's common to redirect maven output to a build log
+/*.log

--- a/pom.xml
+++ b/pom.xml
@@ -1,62 +1,131 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.mxgraph</groupId>
-  <artifactId>jgraphx</artifactId>
-  <version>3.8.0</version>
-  <packaging>jar</packaging>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <url>http://www.jgraph.com</url>
+	<groupId>com.mxgraph</groupId>
+	<artifactId>jgraphx</artifactId>
+	<version>3.8.0</version>
+	<packaging>jar</packaging>
 
-  <properties>
-  
-   <maven.compiler.source>1.5</maven.compiler.source>
-   <maven.compiler.target>1.5</maven.compiler.target>
-   <maven.compiler.compilerVersion>1.5</maven.compiler.compilerVersion>
-   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-  <dependencies>
-  </dependencies>
-    
-  <build>
-			<sourceDirectory>src</sourceDirectory>
+	<url>http://www.jgraph.com</url>
+
+	<properties>
+		<maven.compiler.source>1.5</maven.compiler.source>
+		<maven.compiler.target>1.5</maven.compiler.target>
+		<maven.compiler.compilerVersion>1.5</maven.compiler.compilerVersion>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+	</dependencies>
+
+	<build>
+		<sourceDirectory>src</sourceDirectory>
 		<resources>
 			<resource>
 				<directory>src</directory>
 				<excludes>
-					<exclude>**.java</exclude>
+					<exclude>**/*.java</exclude>
 				</excludes>
 			</resource>
 		</resources>
-  	<plugins>
-		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-jar-plugin</artifactId>
-			<version>2.6</version>
-			<configuration>
-				<archive>
-					<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-				</archive>
-			</configuration>
-		</plugin>
-		<plugin>
-			<groupId>org.apache.felix</groupId>
-			<artifactId>maven-bundle-plugin</artifactId>
-			<version>3.0.1</version>
-			<executions>
-				<execution>
-					<phase>process-classes</phase>
-					<goals>
-						<goal>manifest</goal>
-					</goals>
-				</execution>
-			</executions>
-			<configuration>
-				<instructions>
-					<Bundle-Vendor>see https://github.com/jgraph/jgraphx)</Bundle-Vendor>
-				</instructions>
-			</configuration>
-		</plugin>
-  	</plugins>
-  </build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<instructions>
+						<Bundle-Vendor>see https://github.com/jgraph/jgraphx</Bundle-Vendor>
+					</instructions>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M1</version>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<!-- require fixed plugin versions for a repeatable build -->
+								<requirePluginVersions />
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- generate javadoc by executing mvn javadoc:jar -->
+			<plugin>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<!-- skip invalid HTML -->
+					<doclint>none</doclint>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>2.6.1</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.0.2</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.16</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-install-plugin</artifactId>
+				<version>2.5.2</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.2</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-site-plugin</artifactId>
+				<version>3.3</version>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
Fixes the exclusion filter, so that the java files are not included in the main jar.
Added a sources jar generation.
Fixed formatting (mixed spaces and tabs -> tabs).
Specified plugin versions for a repeatable build.
Optional javadoc generation (by an explicit mvn javadoc:jar command).
Added a .gitignore for Maven/Eclipse output & Eclipse project files.