### PR TITLE
Assign an Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 			<configuration>
 				<instructions>
 					<Bundle-Vendor>see https://github.com/jgraph/jgraphx)</Bundle-Vendor>
+          <Automatic-Module-Name>com.mxgraph.jgraphx</Automatic-Module-Name>
 				</instructions>
 			</configuration>
 		</plugin>


### PR DESCRIPTION
This adds an Automatic-Module-Name entry with value com.mxgraph.jgraphx
to the jar manifest. This provides a stable name upon which Java 9
modules can depend in modular projects.

See http://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html

Fix #91