### PR TITLE
fixes #101 NullPointerException in mxCellRenderer.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/bin/
+/target/
+# ignore Eclipse project
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,14 @@
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
-  </dependencies>
+	<!-- https://mvnrepository.com/artifact/junit/junit -->
+	<dependency>
+		<groupId>junit</groupId>
+		<artifactId>junit</artifactId>
+		<version>4.12</version>
+		<scope>test</scope>
+	</dependency>
+	</dependencies>
     
   <build>
 			<sourceDirectory>src</sourceDirectory>

--- a/src/com/mxgraph/util/mxCellRenderer.java
+++ b/src/com/mxgraph/util/mxCellRenderer.java
@@ -176,6 +176,9 @@ public class mxCellRenderer
 
 				});
 
+		if (canvas==null) {
+		  return null;
+		}
 		return canvas.getDocument();
 	}
 

--- a/src/test/java/com/mxgraph/util/TestMxCellRenderer.java
+++ b/src/test/java/com/mxgraph/util/TestMxCellRenderer.java
@@ -1,0 +1,24 @@
+package com.mxgraph.util;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.awt.Color;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import com.mxgraph.view.mxGraph;
+
+public class TestMxCellRenderer {
+
+  @Test
+  public void testSVG() {
+    mxGraph mxg=new mxGraph();
+    double scale=1.0;
+    // https://stackoverflow.com/questions/51008766/jgraphx-how-to-export-svg-file-from-graph?rq=1
+    Color background = Color.WHITE;
+    Document svgDoc = mxCellRenderer.createSvgDocument(mxg, null, scale,
+        background, null);
+    assertNotNull(svgDoc);
+  }
+}


### PR DESCRIPTION
The Nullpointer also happens in other cases. To trace it checking the canvas to be null is a first start to have a handle for debugging and be able to work on the problem in surrounding code without having to catch a NullPointer Exception. The check for the svgdoc to be null seems more appropriate to me.